### PR TITLE
'HEAD' requests have blank response (therefore they are not JSON data)

### DIFF
--- a/lib/Teepee.js
+++ b/lib/Teepee.js
@@ -682,7 +682,8 @@ Teepee.prototype.request = function (options, cb) {
                     disposeRequestOrResponse(currentRequest);
                     currentRequest = null;
                     response.body = Buffer.concat(responseBodyChunks);
-                    if (isContentTypeJson(response.headers['content-type'])) {
+                    if (isContentTypeJson(response.headers['content-type']) && response.req.method !== 'HEAD') {
+                        // 'HEAD' requests have blank response
                         try {
                             response.body = JSON.parse(response.body.toString('utf-8'));
                         } catch (e) {


### PR DESCRIPTION
Another possible fix would be that 'HEAD' requests don't set the response header for JSON (isContentTypeJson(response.headers['content-type']))
