### PR TITLE
Added failing test for #3, error thrown when request url contains a p…

### DIFF
--- a/test/Teepee.js
+++ b/test/Teepee.js
@@ -1983,4 +1983,12 @@ describe('Teepee', function () {
             response: 200
         }, 'not to error');
     });
+
+    it('should accept a url with a pipe in the query string', function () {
+        return expect(function () {
+            return teepee('https://fonts.googleapis.com/css?family=Just+Another+Hand|Inconsolata:700');
+        }, 'with http mocked out', {
+            response: 200
+        }, 'not to error');
+    });
 });


### PR DESCRIPTION
…ipe character in the query string
